### PR TITLE
Fix snake animation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
   
 [![Nihar's wakatime stats](https://github-readme-stats.vercel.app/api/wakatime?username=Nihar&theme=github_dark)](https://github.com/Nihar16)
 
-## A hungry 🐍 ate my work 🙂 
-![github-snake](https://raw.githubusercontent.com/Nihar16/Nihar16/output/github-snake.gif)
+## A hungry 🐍 ate my work 🙂
+![github-snake](https://raw.githubusercontent.com/Nihar16/Nihar16/output/github-contribution-grid-snake-dark.svg)
 
 
 


### PR DESCRIPTION
## Summary
- fix the link to the GitHub Contribution Snake in dark mode

## Testing
- `curl -I https://raw.githubusercontent.com/Nihar16/Nihar16/output/github-contribution-grid-snake-dark.svg`


------
https://chatgpt.com/codex/tasks/task_e_6855827fcedc8333a4edbfe88b19f088